### PR TITLE
Simplify Namespaces

### DIFF
--- a/src/os/boot/GlobalConstructors.cpp
+++ b/src/os/boot/GlobalConstructors.cpp
@@ -27,4 +27,4 @@ namespace boot {
     extern "C" void callConstructors() {
         for (GlobalConstructor& constructor : std::Span(&startCtors, &endCtors)) { constructor(); }
     }
-}// namespace boot {
+}// namespace boot

--- a/src/os/boot/GlobalConstructors.cpp
+++ b/src/os/boot/GlobalConstructors.cpp
@@ -17,7 +17,7 @@
 
 #include "span.h"
 
-namespace kernel::boot {
+namespace boot {
 
     using GlobalConstructor = void (*)();
 
@@ -27,4 +27,4 @@ namespace kernel::boot {
     extern "C" void callConstructors() {
         for (GlobalConstructor& constructor : std::Span(&startCtors, &endCtors)) { constructor(); }
     }
-}// namespace kernel::boot
+}// namespace boot {

--- a/src/os/boot/boot_info.h
+++ b/src/os/boot/boot_info.h
@@ -32,6 +32,6 @@ namespace boot {
         uintptr_t bootStartLocation;
         uintptr_t bootEndLocation;
     };
-}// namespace boot {
+}// namespace boot
 
 #endif// HEPHAISTOS_BOOT_INFO_H

--- a/src/os/boot/boot_info.h
+++ b/src/os/boot/boot_info.h
@@ -23,15 +23,15 @@
 #include "paging/model/page_directory_entry.h"
 #include "paging/model/page_table_entry.h"
 
-namespace kernel::boot {
+namespace boot {
 
     struct BootInfo {
-        paging::PageDirectoryEntry* pageDirectory;
-        paging::PageTableEntry* bootPageTable;
+        PageDirectoryEntry* pageDirectory;
+        PageTableEntry* bootPageTable;
         uintptr_t baseVirtualAddress;
         uintptr_t bootStartLocation;
         uintptr_t bootEndLocation;
     };
-}// namespace kernel::boot
+}// namespace boot {
 
 #endif// HEPHAISTOS_BOOT_INFO_H

--- a/src/os/boot/elf/boot_elf_loader.cpp
+++ b/src/os/boot/elf/boot_elf_loader.cpp
@@ -20,7 +20,7 @@
 #include <result.h>
 #include <string.h>
 
-namespace kernel::boot::elf {
+namespace boot {
 
     auto getExecutableElfInfo(const Elf32_Ehdr* header, uintptr_t headerAddress) -> ElfInfo;
 
@@ -98,4 +98,4 @@ namespace kernel::boot::elf {
     void loadElf(const DynamicExecutableElf& elf, uintptr_t loadAddress) {
         loadExecutableElf(elf.headerAddress, elf.programHeaders, loadAddress);
     }
-}// namespace kernel::boot::elf
+}// namespace boot {

--- a/src/os/boot/elf/boot_elf_loader.cpp
+++ b/src/os/boot/elf/boot_elf_loader.cpp
@@ -98,4 +98,4 @@ namespace boot {
     void loadElf(const DynamicExecutableElf& elf, uintptr_t loadAddress) {
         loadExecutableElf(elf.headerAddress, elf.programHeaders, loadAddress);
     }
-}// namespace boot {
+}// namespace boot

--- a/src/os/boot/elf/boot_elf_loader.cpp
+++ b/src/os/boot/elf/boot_elf_loader.cpp
@@ -84,8 +84,8 @@ namespace boot {
 
     void loadExecutableElf(uintptr_t headerAddress, std::Span<const Elf32_Phdr> programHeaders, uintptr_t loadAddress) {
         for (const auto& programHeader : programHeaders) {
-            const auto* programAddress = std::bit_cast<void*>(headerAddress + programHeader.p_offset);
-            auto* memoryAddress = std::bit_cast<void*>(loadAddress);
+            const auto* programAddress = std::bit_cast<std::byte*>(headerAddress + programHeader.p_offset);
+            auto* memoryAddress = std::bit_cast<std::byte*>(loadAddress);
             memset(memoryAddress, 0, programHeader.p_memsz + programHeader.p_vaddr);
             memcpy(memoryAddress, programAddress, programHeader.p_filesz);
         }

--- a/src/os/boot/elf/boot_elf_loader.h
+++ b/src/os/boot/elf/boot_elf_loader.h
@@ -23,7 +23,7 @@
 #include <span.h>
 #include <variant_base.h>
 
-namespace kernel::boot::elf {
+namespace boot {
 
     struct StaticExecutableElf {
         std::uintptr_t entryAddress;
@@ -47,6 +47,6 @@ namespace kernel::boot::elf {
     void loadElf(const StaticExecutableElf& elf);
 
     void loadElf(const DynamicExecutableElf& elf, uintptr_t loadAddress);
-}// namespace kernel::boot::elf
+}// namespace boot {
 
 #endif// HEPHAISTOS_BOOT_ELF_LOADER_H

--- a/src/os/boot/elf/boot_elf_loader.h
+++ b/src/os/boot/elf/boot_elf_loader.h
@@ -47,6 +47,6 @@ namespace boot {
     void loadElf(const StaticExecutableElf& elf);
 
     void loadElf(const DynamicExecutableElf& elf, uintptr_t loadAddress);
-}// namespace boot {
+}// namespace boot
 
 #endif// HEPHAISTOS_BOOT_ELF_LOADER_H

--- a/src/os/boot/gdt/global_descriptor.cpp
+++ b/src/os/boot/gdt/global_descriptor.cpp
@@ -18,7 +18,7 @@
 #include "global_descriptor.h"
 #include <stdoffset.h>
 
-namespace kernel::boot::gdt {
+namespace boot {
 
     /**
      * Constructs a Global descriptor that can be inserted in a Global descriptor table. This takes a set of
@@ -38,15 +38,15 @@ namespace kernel::boot::gdt {
         const Access& access,
         const Flags& flags
     ) -> GlobalDescriptor {
-        return GlobalDescriptor { .lowerLimit = static_cast<uint16_t>((memoryLimit & Mask16Bit)),
-                                  .lowerBase = static_cast<uint16_t>((baseAddress & Mask16Bit)),
-                                  .midBase = static_cast<uint8_t>((baseAddress >> Offset16Bit) & Mask8Bit),
+        return GlobalDescriptor { .lowerLimit = static_cast<uint16_t>((memoryLimit & std::Mask16Bit)),
+                                  .lowerBase = static_cast<uint16_t>((baseAddress & std::Mask16Bit)),
+                                  .midBase = static_cast<uint8_t>((baseAddress >> std::Offset16Bit) & std::Mask8Bit),
                                   .access = access,
-                                  .upperLimit = static_cast<uint8_t>((memoryLimit >> Offset16Bit) & Mask4Bit),
+                                  .upperLimit = static_cast<uint8_t>((memoryLimit >> std::Offset16Bit) & std::Mask4Bit),
                                   .available = flags.available,
                                   .longMode = flags.longMode,
                                   .size = flags.size,
                                   .granularity = flags.granularity,
-                                  .upperBase = static_cast<uint8_t>((baseAddress >> Offset24Bit) & Mask8Bit) };
+                                  .upperBase = static_cast<uint8_t>((baseAddress >> std::Offset24Bit) & std::Mask8Bit) };
     }
-}// namespace kernel::boot::gdt
+}// namespace boot {

--- a/src/os/boot/gdt/global_descriptor.cpp
+++ b/src/os/boot/gdt/global_descriptor.cpp
@@ -33,7 +33,7 @@ namespace boot {
      * @return Global Descriptor constructed from the parameters.
      */
     auto constructGlobalDescriptor(
-        const uint32_t baseAddress,
+        const uintptr_t baseAddress,
         const uint32_t memoryLimit,
         const Access& access,
         const Flags& flags
@@ -47,6 +47,7 @@ namespace boot {
                                   .longMode = flags.longMode,
                                   .size = flags.size,
                                   .granularity = flags.granularity,
-                                  .upperBase = static_cast<uint8_t>((baseAddress >> std::Offset24Bit) & std::Mask8Bit) };
+                                  .upperBase =
+                                      static_cast<uint8_t>((baseAddress >> std::Offset24Bit) & std::Mask8Bit) };
     }
-}// namespace boot {
+}// namespace boot

--- a/src/os/boot/gdt/global_descriptor.h
+++ b/src/os/boot/gdt/global_descriptor.h
@@ -177,7 +177,7 @@ namespace boot {
      * @return Global Descriptor constructed from the parameters.
      */
     GlobalDescriptor
-        constructGlobalDescriptor(uint32_t baseAddress, uint32_t memoryLimit, const Access& access, const Flags& flags);
-}// namespace boot {
+        constructGlobalDescriptor(uintptr_t baseAddress, uint32_t memoryLimit, const Access& access, const Flags& flags);
+}// namespace boot
 
 #endif// HEPHAIST_OS_KERNEL_BOOT_GDT_GLOBAL_DESCRIPTOR_H

--- a/src/os/boot/gdt/global_descriptor.h
+++ b/src/os/boot/gdt/global_descriptor.h
@@ -20,7 +20,7 @@
 
 #include <cstdint>
 
-namespace kernel::boot::gdt {
+namespace boot {
 
     /**
      * Describes the privilege levels available in x86, mapped to the ring level. This class
@@ -178,6 +178,6 @@ namespace kernel::boot::gdt {
      */
     GlobalDescriptor
         constructGlobalDescriptor(uint32_t baseAddress, uint32_t memoryLimit, const Access& access, const Flags& flags);
-}// namespace kernel::boot::gdt
+}// namespace boot {
 
 #endif// HEPHAIST_OS_KERNEL_BOOT_GDT_GLOBAL_DESCRIPTOR_H

--- a/src/os/boot/gdt/global_descriptor_table.cpp
+++ b/src/os/boot/gdt/global_descriptor_table.cpp
@@ -18,7 +18,7 @@
 #include "global_descriptor_table.h"
 #include "array.h"
 
-namespace kernel::boot::gdt {
+namespace boot {
 
     // Array of Global Descriptors that defines the Global Descriptor Table.
     std::Array<GlobalDescriptor, 6> globalDescriptorTable {
@@ -55,4 +55,4 @@ namespace kernel::boot::gdt {
         // Load the GDT from the pointer into the CPU Registers.
         loadGdtTable(&gdtPointer);
     }
-}// namespace kernel::boot::gdt
+}// namespace boot {

--- a/src/os/boot/gdt/global_descriptor_table.cpp
+++ b/src/os/boot/gdt/global_descriptor_table.cpp
@@ -55,4 +55,4 @@ namespace boot {
         // Load the GDT from the pointer into the CPU Registers.
         loadGdtTable(&gdtPointer);
     }
-}// namespace boot {
+}// namespace boot

--- a/src/os/boot/gdt/global_descriptor_table.h
+++ b/src/os/boot/gdt/global_descriptor_table.h
@@ -128,6 +128,6 @@ namespace boot {
      * @param tssDescriptor provides the task state segments descriptor to be added to the array.
      */
     void initializeGlobalDescriptorTable(const GlobalDescriptor& tssDescriptor);
-}// namespace boot {
+}// namespace boot
 
 #endif// HEPHAIST_OS_KERNEL_BOOT_GDT_GLOBAL_DESCRIPTOR_TABLE_H

--- a/src/os/boot/gdt/global_descriptor_table.h
+++ b/src/os/boot/gdt/global_descriptor_table.h
@@ -21,7 +21,7 @@
 #include "global_descriptor.h"
 #include <stdoffset.h>
 
-namespace kernel::boot::gdt {
+namespace boot {
 
     /**
      * Defines a pointer to the first Global Descriptor in an array of Global Descriptors that make
@@ -128,6 +128,6 @@ namespace kernel::boot::gdt {
      * @param tssDescriptor provides the task state segments descriptor to be added to the array.
      */
     void initializeGlobalDescriptorTable(const GlobalDescriptor& tssDescriptor);
-}// namespace kernel::boot::gdt
+}// namespace boot {
 
 #endif// HEPHAIST_OS_KERNEL_BOOT_GDT_GLOBAL_DESCRIPTOR_TABLE_H

--- a/src/os/boot/grub/multiboot_info.h
+++ b/src/os/boot/grub/multiboot_info.h
@@ -20,7 +20,7 @@
 
 #include <stdoffset.h>
 
-namespace kernel::boot {
+namespace boot {
 
     static constexpr uint8_t MULTIBOOT_MEMORY_AVAILABLE = 1;
 
@@ -104,5 +104,5 @@ namespace kernel::boot {
         uint32_t vbeInterfaceOff;
         uint32_t vbeInterfaceLength;
     };
-}// namespace kernel::boot
+}// namespace boot {
 #endif// HEPHAIST_OS_KERNEL_BOOT_MULTIBOOT_INFO_H

--- a/src/os/boot/grub/multiboot_info.h
+++ b/src/os/boot/grub/multiboot_info.h
@@ -104,5 +104,5 @@ namespace boot {
         uint32_t vbeInterfaceOff;
         uint32_t vbeInterfaceLength;
     };
-}// namespace boot {
+}// namespace boot
 #endif// HEPHAIST_OS_KERNEL_BOOT_MULTIBOOT_INFO_H

--- a/src/os/boot/idt/exceptions/exception_handler.cpp
+++ b/src/os/boot/idt/exceptions/exception_handler.cpp
@@ -19,8 +19,7 @@
 
 #include <format.h>
 
-namespace kernel::boot::idt {
-
+namespace boot {
     // handles an exception for the provided exception info
     extern "C" void handleException(ExceptionInfo exceptionInfo) {
 
@@ -32,4 +31,4 @@ namespace kernel::boot::idt {
 
         while (true) {}
     }
-}// namespace kernel::boot::idt
+}// namespace boot

--- a/src/os/boot/idt/exceptions/exception_handler.h
+++ b/src/os/boot/idt/exceptions/exception_handler.h
@@ -23,8 +23,7 @@
 
 #include "idt/model/handler_registers.h"
 
-namespace kernel::boot::idt {
-
+namespace boot {
     /**
      *
      */
@@ -77,6 +76,6 @@ namespace kernel::boot::idt {
      *
      */
     extern "C" [[noreturn]] void handleException(ExceptionInfo exceptionInfo);
-}// namespace kernel::boot::idt
+}// namespace boot
 
 #endif// HEPHAISTOS_EXCEPTION_HANDLER_H

--- a/src/os/boot/idt/interrupt_descriptor.cpp
+++ b/src/os/boot/idt/interrupt_descriptor.cpp
@@ -19,7 +19,7 @@
 #include <bit>
 #include <stdoffset.h>
 
-namespace kernel::boot::idt {
+namespace boot {
 
     /**
      * Constructs an Interrupt Descriptor that can be inserted in a Interrupt descriptor table.
@@ -35,14 +35,15 @@ namespace kernel::boot::idt {
      */
     auto constructInterruptDescriptor(int (*handler)(), GateType type) -> InterruptDescriptor {
         return InterruptDescriptor {
-            .lowerOffset = static_cast<uint16_t>(std::bit_cast<uintptr_t>(handler) & Mask16Bit),
+            .lowerOffset = static_cast<uint16_t>(std::bit_cast<uintptr_t>(handler) & std::Mask16Bit),
             .selector = InterruptSegment,
             .zero = 0,
             .gateType = TypeAttributes { .gateType = type,
                                          .storageSegment = 0,
                                          .descriptorPrivilege = DescriptorPrivilege::Kernel,
                                          .isPresent = true },
-            .higherOffset = static_cast<uint16_t>((std::bit_cast<uintptr_t>(handler) >> Offset16Bit) & Mask16Bit)
+            .higherOffset =
+                static_cast<uint16_t>((std::bit_cast<uintptr_t>(handler) >> std::Offset16Bit) & std::Mask16Bit)
         };
     }
-}// namespace kernel::boot::idt
+}// namespace boot

--- a/src/os/boot/idt/interrupt_descriptor.h
+++ b/src/os/boot/idt/interrupt_descriptor.h
@@ -20,7 +20,7 @@
 
 #include <cstdint>
 
-namespace kernel::boot::idt {
+namespace boot {
 
     constexpr uint16_t InterruptSegment = 0x08;
 
@@ -56,6 +56,6 @@ namespace kernel::boot::idt {
      * @return an interrupt descriptor setup to call the provided method on the interrupt firing.
      */
     auto constructInterruptDescriptor(int (*handler)(), GateType type) -> InterruptDescriptor;
-}// namespace kernel::boot::idt
+}// namespace boot
 
 #endif// HEPHAIST_OS_KERNEL_BOOT_IDT_INTERRUPT_DESCRIPTOR_H

--- a/src/os/boot/idt/interrupt_descriptor_table.cpp
+++ b/src/os/boot/idt/interrupt_descriptor_table.cpp
@@ -18,7 +18,7 @@
 #include "interrupt_descriptor_table.h"
 #include "array.h"
 
-namespace kernel::boot::idt {
+namespace boot {
 
     // Array of Interrupt Descriptors that defines the Interrupt Descriptor Table.
     static const std::Array<InterruptDescriptor, IDT_TABLE_LENGTH> interruptDescriptorTable {
@@ -82,4 +82,4 @@ namespace kernel::boot::idt {
      *
      */
     void initializeInterruptDescriptorTable() { loadIdtTable(&idtPointer); }
-}// namespace kernel::boot::idt
+}// namespace boot

--- a/src/os/boot/idt/interrupt_descriptor_table.h
+++ b/src/os/boot/idt/interrupt_descriptor_table.h
@@ -23,7 +23,7 @@
 #include "interrupt_descriptor.h"
 
 
-namespace kernel::boot::idt {
+namespace boot {
 
     /**
      *
@@ -102,6 +102,6 @@ namespace kernel::boot::idt {
     extern "C" int fireInterruptRequest13();
     extern "C" int fireInterruptRequest14();
     extern "C" int fireInterruptRequest15();
-}// namespace kernel::boot::idt
+}// namespace boot
 
 #endif// HEPHAIST_OS_KERNEL_BOOT_IDT_INTERRUPT_DESCRIPTOR_TABLE_H

--- a/src/os/boot/idt/interrupts/interrupt_handler.cpp
+++ b/src/os/boot/idt/interrupts/interrupt_handler.cpp
@@ -21,7 +21,7 @@
 #include "../hal/io/io.h"
 #include <format.h>
 
-namespace kernel::boot::idt {
+namespace boot {
 
 
     void handleKeyboardPress(InterruptInfo interruptInfo) {
@@ -49,4 +49,4 @@ namespace kernel::boot::idt {
         sendEoiFlag(interruptInfo.interruptCode);
     }
 
-}// namespace kernel::boot::idt
+}// namespace boot

--- a/src/os/boot/idt/interrupts/interrupt_handler.h
+++ b/src/os/boot/idt/interrupts/interrupt_handler.h
@@ -22,7 +22,7 @@
 
 #include "idt/model/handler_registers.h"
 
-namespace kernel::boot::idt {
+namespace boot {
 
     /**
      *
@@ -38,6 +38,6 @@ namespace kernel::boot::idt {
      *
      */
     extern "C" void handleInterrupt(InterruptInfo interruptInfo);
-}// namespace kernel::boot::idt
+}// namespace boot
 
 #endif// HEPHAIST_OS_KERNEL_BOOT_IDT_INTERRUPT_HANDLER_H

--- a/src/os/boot/idt/model/handler_registers.h
+++ b/src/os/boot/idt/model/handler_registers.h
@@ -18,7 +18,7 @@
 #ifndef HEPHAIST_OS_KERNEL_BOOT_IDT_HANDLER_REGISTERS_H
 #define HEPHAIST_OS_KERNEL_BOOT_IDT_HANDLER_REGISTERS_H
 
-namespace kernel::boot::idt {
+namespace boot {
 
     /**
      *
@@ -52,6 +52,6 @@ namespace kernel::boot::idt {
         const uint32_t cs;
         const uint16_t eflags;
     };
-}// namespace kernel::boot::idt
+}// namespace boot
 
 #endif// HEPHAIST_OS_KERNEL_BOOT_IDT_HANDLER_REGISTERS_H

--- a/src/os/boot/idt/pic/programmable_interrupt_controller.cpp
+++ b/src/os/boot/idt/pic/programmable_interrupt_controller.cpp
@@ -19,7 +19,7 @@
 
 #include "io.h"
 
-namespace kernel::boot::idt {
+namespace boot {
 
     // Maps the overlapping interrupts to after the exceptions.
     void remapProgrammableInterruptController(uint8_t masterOffset, uint8_t slaveOffset) {
@@ -66,4 +66,4 @@ namespace kernel::boot::idt {
 
         hal::writeToPort(masterPicAddress, picEoiFlag);
     }
-}// namespace kernel::boot::idt
+}// namespace boot

--- a/src/os/boot/idt/pic/programmable_interrupt_controller.h
+++ b/src/os/boot/idt/pic/programmable_interrupt_controller.h
@@ -20,7 +20,7 @@
 
 #include <cstdint>
 
-namespace kernel::boot::idt {
+namespace boot {
     constexpr uint8_t masterPicAddress = 0x20;// IO Address of Master PIC
     constexpr uint8_t slavePicAddress = 0xA0;// IO Address of Slave PIC
     constexpr uint8_t masterPicDataAddress = 0x21;// IO Data Address of Master PIC
@@ -53,6 +53,6 @@ namespace kernel::boot::idt {
      * @param interruptCode
      */
     void sendEoiFlag(uint32_t interruptCode);
-}// namespace kernel::boot::idt
+}// namespace boot
 
 #endif// HEPHAIST_OS_KERNEL_BOOT_IDT_PROGRAMMABLE_INTERRUPT_CONTROLLER_H

--- a/src/os/boot/init.cpp
+++ b/src/os/boot/init.cpp
@@ -26,13 +26,7 @@
 #include <serial_port.h>
 #include <tss/task_state_segment.h>
 
-extern "C" void
-    init(
-        boot::MultiBootInfo* info,
-        uint32_t magic,
-        uint32_t stackPointer,
-        boot::BootInfo bootInfo
-    ) {
+extern "C" void init(boot::MultiBootInfo* info, uint32_t magic, uint32_t stackPointer, boot::BootInfo bootInfo) {
     boot::initializeSerialPort();
     std::print("INFO: System init\n");
 
@@ -47,8 +41,7 @@ extern "C" void
     const auto bootModules = std::Span<boot::ModuleEntry> { info->modulePtr, info->moduleCount };
     const auto nextAvailableMemory = findNextAvailableMemory(bootModules, bootInfo);
 
-    auto allocator =
-        boot::BootAllocator(bootInfo.baseVirtualAddress, nextAvailableMemory, bootInfo.bootPageTable);
+    auto allocator = boot::BootAllocator(bootInfo.baseVirtualAddress, nextAvailableMemory, bootInfo.bootPageTable);
     const auto kernelAddress = loadModules(bootModules, allocator, bootInfo);
 
     boot::unmapLowerKernel(bootInfo.pageDirectory);

--- a/src/os/boot/init.cpp
+++ b/src/os/boot/init.cpp
@@ -69,6 +69,7 @@ namespace boot {
                 &connection,
                 [](const void*) { /* Serial port cannot be de-referenced. */ },
                 [](const void* pointer, char character) {
+                    // todo: std::any here?
                     static_cast<const debug::SerialPortConnection*>(pointer)->write(character);
                 },
                 [](const void*) { /* Serial Port self increments. */ },

--- a/src/os/boot/init.h
+++ b/src/os/boot/init.h
@@ -26,8 +26,7 @@ namespace boot {
 
     extern "C" void enableInterrupts();
 
-    extern "C" void
-        init(MultiBootInfo* info, uint32_t magic, uint32_t stackPointer, BootInfo bootInfo);
+    extern "C" void init(MultiBootInfo* info, uint32_t magic, uint32_t stackPointer, BootInfo bootInfo);
 
     void initializeSerialPort();
 

--- a/src/os/boot/init.h
+++ b/src/os/boot/init.h
@@ -21,14 +21,13 @@
 #include "grub/multiboot_info.h"
 #include <boot_info.h>
 
-namespace kernel::boot {
-
+namespace boot {
     extern "C" void loadKernelSegment();
 
     extern "C" void enableInterrupts();
 
     extern "C" void
-        init(kernel::boot::MultiBootInfo* info, uint32_t magic, uint32_t stackPointer, kernel::boot::BootInfo bootInfo);
+        init(MultiBootInfo* info, uint32_t magic, uint32_t stackPointer, BootInfo bootInfo);
 
     void initializeSerialPort();
 
@@ -39,6 +38,6 @@ namespace kernel::boot {
     auto findNextAvailableMemory(const std::Span<ModuleEntry>& bootModules, const BootInfo& bootInfo) -> uintptr_t;
 
     void enterKernelModule(uintptr_t kernelAddress);
-}// namespace kernel::boot
+}// namespace boot
 
 #endif// HEPHAISTOS_INIT_H

--- a/src/os/boot/memory/boot_allocator.cpp
+++ b/src/os/boot/memory/boot_allocator.cpp
@@ -18,12 +18,12 @@
 #include "boot_allocator.h"
 #include <bit>
 
-namespace kernel::boot {
+namespace boot {
 
     BootAllocator::BootAllocator(
         std::uintptr_t virtualBaseAddress,
         std::uintptr_t physicalAddress,
-        paging::PageTableEntry* kernelPageTable
+        PageTableEntry* kernelPageTable
     )
         : currentAddress(physicalAddress), virtualAddress(virtualBaseAddress), pageTable(kernelPageTable) {}
 
@@ -31,9 +31,9 @@ namespace kernel::boot {
         const auto startAddress = (currentAddress / alignment) + (currentAddress % alignment ? alignment : 0);
         const auto endAddress = startAddress + count;
 
-        paging::mapAddressRangeInTable(pageTable, virtualAddress + currentAddress, currentAddress, endAddress);
+        mapAddressRangeInTable(pageTable, virtualAddress + currentAddress, currentAddress, endAddress);
 
         currentAddress = endAddress;
         return std::bit_cast<void*>(virtualAddress + startAddress);
     }
-}// namespace kernel::boot
+}// namespace boot

--- a/src/os/boot/memory/boot_allocator.cpp
+++ b/src/os/boot/memory/boot_allocator.cpp
@@ -27,13 +27,13 @@ namespace boot {
     )
         : currentAddress(physicalAddress), virtualAddress(virtualBaseAddress), pageTable(kernelPageTable) {}
 
-    auto BootAllocator::allocate(std::size_t count, std::size_t alignment) -> void* {
+    auto BootAllocator::allocate(std::size_t count, std::size_t alignment) -> std::byte* {
         const auto startAddress = (currentAddress / alignment) + (currentAddress % alignment ? alignment : 0);
         const auto endAddress = startAddress + count;
 
         mapAddressRangeInTable(pageTable, virtualAddress + currentAddress, currentAddress, endAddress);
 
         currentAddress = endAddress;
-        return std::bit_cast<void*>(virtualAddress + startAddress);
+        return std::bit_cast<std::byte*>(virtualAddress + startAddress);
     }
 }// namespace boot

--- a/src/os/boot/memory/boot_allocator.h
+++ b/src/os/boot/memory/boot_allocator.h
@@ -18,8 +18,8 @@
 #ifndef HEPHAISTOS_BOOTALLOCATOR_H
 #define HEPHAISTOS_BOOTALLOCATOR_H
 
-#include "paging/paging.h"
-#include "cstddef"
+#include <cstddef>
+#include <paging/paging.h>
 #include <cstdint>
 
 namespace boot {

--- a/src/os/boot/memory/boot_allocator.h
+++ b/src/os/boot/memory/boot_allocator.h
@@ -19,6 +19,7 @@
 #define HEPHAISTOS_BOOTALLOCATOR_H
 
 #include "paging/paging.h"
+#include "cstddef"
 #include <cstdint>
 
 namespace boot {
@@ -35,7 +36,7 @@ namespace boot {
             PageTableEntry* kernelPageTable
         );
 
-        auto allocate(std::size_t count, std::size_t alignment = 1) -> void*;
+        auto allocate(std::size_t count, std::size_t alignment = 1) -> std::byte*;
     };
 }// namespace boot
 

--- a/src/os/boot/memory/boot_allocator.h
+++ b/src/os/boot/memory/boot_allocator.h
@@ -21,22 +21,22 @@
 #include "paging/paging.h"
 #include <cstdint>
 
-namespace kernel::boot {
+namespace boot {
 
     class BootAllocator {
         std::uintptr_t currentAddress;
         std::uintptr_t virtualAddress;
-        paging::PageTableEntry* pageTable;
+        PageTableEntry* pageTable;
 
       public:
         BootAllocator(
             std::uintptr_t baseVirtualAddress,
             std::uintptr_t physicalAddress,
-            paging::PageTableEntry* kernelPageTable
+            PageTableEntry* kernelPageTable
         );
 
         auto allocate(std::size_t count, std::size_t alignment = 1) -> void*;
     };
-}// namespace kernel::boot
+}// namespace boot
 
 #endif// HEPHAISTOS_BOOTALLOCATOR_H

--- a/src/os/boot/modules/module_loader.h
+++ b/src/os/boot/modules/module_loader.h
@@ -24,8 +24,7 @@
 #include <elf/boot_elf_loader.h>
 #include <string_view.h>
 
-namespace kernel::boot {
-
+namespace boot {
     struct LoadedModule {
         std::StringView name;
         uintptr_t address;
@@ -37,9 +36,9 @@ namespace kernel::boot {
     auto loadBootModule(const ModuleEntry& bootModule, BootAllocator& allocator, uintptr_t baseVirtualAddress)
         -> std::Result<LoadedModule>;
 
-    auto loadElf(const elf::StaticExecutableElf& elf, const BootAllocator&) -> uintptr_t;
+    auto loadElf(const StaticExecutableElf& elf, const BootAllocator&) -> uintptr_t;
 
-    auto loadElf(const elf::DynamicExecutableElf& elf, BootAllocator&) -> uintptr_t;
-}// namespace kernel::boot
+    auto loadElf(const DynamicExecutableElf& elf, BootAllocator&) -> uintptr_t;
+}// namespace boot
 
 #endif// HEPHAISTOS_MODULE_LOADER_H

--- a/src/os/boot/paging/model/page_directory_entry.h
+++ b/src/os/boot/paging/model/page_directory_entry.h
@@ -22,7 +22,7 @@
 
 #include "page_table_entry.h"
 
-namespace kernel::boot::paging {
+namespace boot {
 
     // Defines the access flags of a given Page Directory Entry.
     struct [[gnu::packed]] PageDirectoryAccess {
@@ -45,6 +45,6 @@ namespace kernel::boot::paging {
         uintptr_t address : 20 = 0;
     };
 
-}// namespace kernel::boot::paging
+}// namespace boot
 
 #endif// HEPHAIST_OS_KERNEL_BOOT_PAGING_PAGE_DIRECTORY_ENTRY_H

--- a/src/os/boot/paging/model/page_table_entry.h
+++ b/src/os/boot/paging/model/page_table_entry.h
@@ -20,7 +20,7 @@
 
 #include <cstdint>
 
-namespace kernel::boot::paging {
+namespace boot {
 
     // Defines the access flags of a given Page Table Entry.
     struct [[gnu::packed]] PageTableAccess {
@@ -42,6 +42,6 @@ namespace kernel::boot::paging {
         uint8_t unused : 3 = 0;
         uint32_t address : 20 = 0x0;
     };
-}// namespace kernel::boot::paging
+}// namespace boot
 
 #endif// HEPHAIST_OS_KERNEL_BOOT_PAGING_PAGE_TABLE_ENTRY_H

--- a/src/os/boot/paging/model/paging_constants.h
+++ b/src/os/boot/paging/model/paging_constants.h
@@ -20,7 +20,7 @@
 
 #include "cstdint"
 
-namespace kernel::boot::paging {
+namespace boot {
 
     // Page directory
     static constexpr std::size_t PAGE_DIRECTORY_SIZE = 1024;
@@ -28,6 +28,6 @@ namespace kernel::boot::paging {
     static constexpr std::size_t PAGE_TABLE_SIZE = 1024;
 
     static constexpr std::size_t PAGE_SIZE = 0x1000;
-}// namespace kernel::boot::paging
+}// namespace boot
 
 #endif// HEPHAEST_OS_KERNEL_BOOT_PAGING_MODEL_PAGING_CONSTANTS_H

--- a/src/os/boot/paging/paging.cpp
+++ b/src/os/boot/paging/paging.cpp
@@ -25,7 +25,7 @@
 #include "model/page_directory_entry.h"
 #include "span.h"
 
-namespace kernel::boot::paging {
+namespace boot {
 
     struct EntryAddressMask {
         uint16_t : 12;
@@ -68,7 +68,7 @@ namespace kernel::boot::paging {
         PageTableEntry* table
     ) {
         auto address = std::bit_cast<uintptr_t>(table);
-        auto index = (virtualAddress >> Offset22Bit) & Mask10Bit;
+        auto index = (virtualAddress >> std::Offset22Bit) & std::Mask10Bit;
         directory[index] = { .access = PageDirectoryAccess { .isPresent = true, .canWrite = true },
                              .address = std::bit_cast<EntryAddressMask>(address).top };
     }
@@ -140,4 +140,4 @@ namespace kernel::boot::paging {
             .access = PageDirectoryAccess { .canWrite = true },
         };
     }
-}// namespace kernel::boot::paging
+}// namespace boot

--- a/src/os/boot/paging/paging.h
+++ b/src/os/boot/paging/paging.h
@@ -22,13 +22,13 @@
 #include "grub/multiboot_info.h"
 #include "model/page_directory_entry.h"
 
-namespace kernel::boot::paging {
+namespace boot {
 
     /**
      * Takes a pointer to the first entry in a @param pageDirectory and loads it to the
      * cr3 register.
      */
-    extern "C" void loadPageDirectory(paging::PageDirectoryEntry* pageDirectory);
+    extern "C" void loadPageDirectory(PageDirectoryEntry* pageDirectory);
 
     /**
      * Enables paging by setting the paging flag in cr0.
@@ -41,8 +41,8 @@ namespace kernel::boot::paging {
      */
     extern "C" void initializePaging(
         MultiBootInfo* info,
-        paging::PageDirectoryEntry* pageDirectory,
-        paging::PageTableEntry* kernelPageTable,
+        PageDirectoryEntry* pageDirectory,
+        PageTableEntry* kernelPageTable,
         uintptr_t virtualKernelBaseAddress,
         uintptr_t kernelStartAddress,
         uintptr_t kernelEndAddress
@@ -55,7 +55,7 @@ namespace kernel::boot::paging {
         uintptr_t endAddress
     );
 
-    void unmapLowerKernel(paging::PageDirectoryEntry* pageDirectoryPointer);
-}// namespace kernel::boot::paging
+    void unmapLowerKernel(PageDirectoryEntry* pageDirectoryPointer);
+}// namespace boot
 
 #endif// HEPHAIST_OS_KERNEL_BOOT_PAGING_PAGING_H

--- a/src/os/boot/tss/task_state_segment.cpp
+++ b/src/os/boot/tss/task_state_segment.cpp
@@ -21,7 +21,7 @@
 
 #include "task_state_segment.h"
 
-namespace kernel::boot::tss {
+namespace boot {
 
     //
     // todo: should be in boot class / struct?
@@ -32,7 +32,7 @@ namespace kernel::boot::tss {
                         .ds = 0x13,
                         .fs = 0x13,
                         .gs = 0x13,
-                        .ioMapBase = sizeof(tss::TssEntry) };
+                        .ioMapBase = sizeof(TssEntry) };
 
     //
     static const uintptr_t tssEntryPtr = std::bit_cast<uintptr_t>(&tssEntry);
@@ -49,15 +49,15 @@ namespace kernel::boot::tss {
         tssEntry.esp0 = stackPointer;
 
         //
-        loadTaskRegister(gdt::Segment::Tss, gdt::Privilege::Kernel);
+        loadTaskRegister(Segment::Tss, Privilege::Kernel);
     }
 
     /**
      *
      * @return
      */
-    auto getTaskStateSegmentDescriptor() -> gdt::GlobalDescriptor {
+    auto getTaskStateSegmentDescriptor() -> GlobalDescriptor {
         //
-        return constructGlobalDescriptor(tssEntryPtr, sizeof(tss::TssEntry), tssEntryAccess, tssFlags);
+        return constructGlobalDescriptor(tssEntryPtr, sizeof(TssEntry), tssEntryAccess, tssFlags);
     }
-}// namespace kernel::boot::tss
+}// namespace boot

--- a/src/os/boot/tss/task_state_segment.h
+++ b/src/os/boot/tss/task_state_segment.h
@@ -74,18 +74,18 @@ namespace boot {
 
     //
     constexpr Flags tssFlags { .available = false,
-                                    .longMode = false,
-                                    .size = Size::Bit16,
-                                    .granularity = Granularity::Byte };
+                               .longMode = false,
+                               .size = Size::Bit16,
+                               .granularity = Granularity::Byte };
 
     //
     constexpr Access tssEntryAccess { .accessed = true,
-                                           .readWritable = false,
-                                           .isConforming = false,
-                                           .isExecutable = true,
-                                           .descriptorType = DescriptorType::System,
-                                           .privilege = Privilege::Kernel,
-                                           .present = true };
+                                      .readWritable = false,
+                                      .isConforming = false,
+                                      .isExecutable = true,
+                                      .descriptorType = DescriptorType::System,
+                                      .privilege = Privilege::Kernel,
+                                      .present = true };
 }// namespace boot
 
 #endif// HEPHAIST_OS_KERNEL_BOOT_TSS_H

--- a/src/os/boot/tss/task_state_segment.h
+++ b/src/os/boot/tss/task_state_segment.h
@@ -20,16 +20,16 @@
 #include "gdt/global_descriptor.h"
 #include <cstdint>
 
-namespace kernel::boot::tss {
+namespace boot {
 
-    extern "C" void loadTaskRegister(gdt::Segment segment, gdt::Privilege privilege);
+    extern "C" void loadTaskRegister(Segment segment, Privilege privilege);
 
     // todo: Move this out to a user space class?
     extern "C" void jumpUserMode();
 
     auto initializeTaskStateSegment(uint32_t stackPointer) -> void;
 
-    auto getTaskStateSegmentDescriptor() -> gdt::GlobalDescriptor;
+    auto getTaskStateSegmentDescriptor() -> GlobalDescriptor;
 
     /**
      *
@@ -73,19 +73,19 @@ namespace kernel::boot::tss {
     };
 
     //
-    constexpr gdt::Flags tssFlags { .available = false,
+    constexpr Flags tssFlags { .available = false,
                                     .longMode = false,
-                                    .size = gdt::Size::Bit16,
-                                    .granularity = gdt::Granularity::Byte };
+                                    .size = Size::Bit16,
+                                    .granularity = Granularity::Byte };
 
     //
-    constexpr gdt::Access tssEntryAccess { .accessed = true,
+    constexpr Access tssEntryAccess { .accessed = true,
                                            .readWritable = false,
                                            .isConforming = false,
                                            .isExecutable = true,
-                                           .descriptorType = gdt::DescriptorType::System,
-                                           .privilege = gdt::Privilege::Kernel,
+                                           .descriptorType = DescriptorType::System,
+                                           .privilege = Privilege::Kernel,
                                            .present = true };
-}// namespace kernel::boot::tss
+}// namespace boot
 
 #endif// HEPHAIST_OS_KERNEL_BOOT_TSS_H

--- a/src/os/kernel/kernel.cpp
+++ b/src/os/kernel/kernel.cpp
@@ -7,7 +7,7 @@
  * (at your option) any later version.
  *
  * HephaistOS is distributed in the hope that it will be useful,
- * bunamespace kernel {t WITHOUT ANY WARRANTY; without even the implied warranty of
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *

--- a/src/os/kernel/kernel.cpp
+++ b/src/os/kernel/kernel.cpp
@@ -7,7 +7,7 @@
  * (at your option) any later version.
  *
  * HephaistOS is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * bunamespace kernel {t WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *

--- a/src/shared/library/LibC/include/stdoffset.h
+++ b/src/shared/library/LibC/include/stdoffset.h
@@ -21,7 +21,7 @@
 #include <cstdint>
 
 // todo: add as library do not copy
-namespace kernel {
+namespace std {
 
     // todo: move to common file
     // Set of bit-masks that can be used to mask parts of an Integer.

--- a/src/shared/library/LibC/include/stdoffset.h
+++ b/src/shared/library/LibC/include/stdoffset.h
@@ -50,6 +50,6 @@ namespace std {
     constexpr uint8_t Offset24Bit = 24U;
 
     constexpr uint8_t Offset32Bit = 32U;
-}// namespace kernel
+}// namespace std
 
 #endif// HEPHAIST_OS_KERNEL_LIB_STD_INT_H

--- a/src/shared/library/LibCpp/include/variant/variant_get.h
+++ b/src/shared/library/LibCpp/include/variant/variant_get.h
@@ -18,8 +18,8 @@
 #ifndef HEPHAIST_OS_SHARED_LIBRARY_CPP_VARIANT_VARIANT_GET_H
 #define HEPHAIST_OS_SHARED_LIBRARY_CPP_VARIANT_VARIANT_GET_H
 
-#include "variant_variant.h"
 #include "result.h"
+#include "variant_variant.h"
 
 namespace std {
 


### PR DESCRIPTION
I went a bit crazy with namespaces creating namespaces for basically every file, not really needed past a boot namespace and kernel namespace at the moment for the boot and kernel modules.
standard library is in the std namespace, and the other libraries such as hal and debug also have their own simple namespaces.