### PR TITLE
moved toolchain step to script and added skip

### DIFF
--- a/.circleci/build-toolchain.sh
+++ b/.circleci/build-toolchain.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if [ -d "/path/to/dir" ]
+then
+  exit 0
+fi
+
+sudo apt-get update
+sudo apt-get install texinfo flex bison nasm graphviz doxygen ccache libmpfr-dev libmpc-dev doxygen --no-install-recommends -y
+
+wget https://github.com/Kitware/CMake/releases/download/v3.26.0/cmake-3.26.0-linux-x86_64.tar.gz
+tar -zxvf cmake-3.26.0-linux-x86_64.tar.gz
+cd cmake-3.26.0-linux-x86_64 || exit 1
+sudo cp -r bin /usr/
+sudo cp -r doc /usr/share/
+sudo cp -r man /usr/share/
+sudo cp -r share /usr/
+cmake --version
+
+mkdir -p cmake-build-release && cmake -DCMAKE_BUILD_TYPE=Release -B cmake-build-release
+cmake --build cmake-build-release --target gcc-12.2.0

--- a/.circleci/build-toolchain.sh
+++ b/.circleci/build-toolchain.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-if [ -d "cmake-build-release/toolchain/output" ]
-then
-  exit 0
-fi
+#if [ -d "cmake-build-release/toolchain/output" ]
+#then
+#  exit 0
+#fi
 
 sudo apt-get update
 sudo apt-get install texinfo flex bison nasm graphviz doxygen ccache libmpfr-dev libmpc-dev doxygen --no-install-recommends -y

--- a/.circleci/build-toolchain.sh
+++ b/.circleci/build-toolchain.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ -d "/path/to/dir" ]
+if [ -d "cmake-build-release/toolchain/output" ]
 then
   exit 0
 fi
@@ -16,7 +16,7 @@ sudo cp -r doc /usr/share/
 sudo cp -r man /usr/share/
 sudo cp -r share /usr/
 
-cd "$CIRCLE_WORKING_DIRECTORY" || exit 1
+cd .. || exit 1
 mkdir -p cmake-build-release
 cmake -DCMAKE_BUILD_TYPE=Release -B cmake-build-release
 cmake --build cmake-build-release --target gcc-12.2.0

--- a/.circleci/build-toolchain.sh
+++ b/.circleci/build-toolchain.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-#if [ -d "cmake-build-release/toolchain/output" ]
-#then
-#  exit 0
-#fi
+if [ -d "cmake-build-release/toolchain/output" ]
+then
+  exit 0
+fi
 
 sudo apt-get update
 sudo apt-get install texinfo flex bison nasm graphviz doxygen ccache libmpfr-dev libmpc-dev doxygen --no-install-recommends -y

--- a/.circleci/build-toolchain.sh
+++ b/.circleci/build-toolchain.sh
@@ -16,6 +16,7 @@ sudo cp -r doc /usr/share/
 sudo cp -r man /usr/share/
 sudo cp -r share /usr/
 
+cd "$CIRCLE_WORKING_DIRECTORY" || exit 1
 mkdir -p cmake-build-release
 cmake -DCMAKE_BUILD_TYPE=Release -B cmake-build-release
 cmake --build cmake-build-release --target gcc-12.2.0

--- a/.circleci/build-toolchain.sh
+++ b/.circleci/build-toolchain.sh
@@ -15,7 +15,7 @@ sudo cp -r bin /usr/
 sudo cp -r doc /usr/share/
 sudo cp -r man /usr/share/
 sudo cp -r share /usr/
-cmake --version
 
-mkdir -p cmake-build-release && cmake -DCMAKE_BUILD_TYPE=Release -B cmake-build-release
+mkdir -p cmake-build-release
+cmake -DCMAKE_BUILD_TYPE=Release -B cmake-build-release
 cmake --build cmake-build-release --target gcc-12.2.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - restore_cache:
           name: Restore Toolchain
           keys:
-            - cache-toolchain-{{ checksum "$CIRCLE_WORKING_DIRECTORY/toolchain/**" }}
+            - cache-toolchain-{{ checksum "~/home/circleci/project/toolchain/**" }}
             - cache-toolchain-
             - toolchain-v1
       - run:
@@ -20,7 +20,7 @@ jobs:
           name: Cache Toolchain
           paths:
             - "$CIRCLE_WORKING_DIRECTORY/cmake-build-release/toolchain/output"
-          key: cache-toolchain-{{ checksum "$CIRCLE_WORKING_DIRECTORY/toolchain/**" }}
+          key: cache-toolchain-{{ checksum "~/home/circleci/project/toolchain/**" }}
 
   build-hephaestOS:
     docker:
@@ -31,7 +31,7 @@ jobs:
       - restore_cache:
           name: Restore Toolchain
           keys:
-            - cache-toolchain-{{ checksum "$CIRCLE_WORKING_DIRECTORY/toolchain/**" }}
+            - cache-toolchain-{{ checksum "~/home/circleci/project/toolchain/**" }}
             - cache-toolchain-
       - run:
           name: "Update libraries"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
             - toolchain-v1
       - run:
           name: "Build toolchain if does not exist"
-          command: "sh $CIRCLE_WORKING_DIRECTORY/.circleci/build-toolchain.sh"
+          command: "$CIRCLE_WORKING_DIRECTORY/.circleci/build-toolchain.sh"
       - save_cache:
           name: Cache Toolchain
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - restore_cache:
           name: Restore Toolchain
           keys:
-            - v1-cache-toolchain-{{ checksum "toolchain/CMakeLists.txt" "toolchain/patches/binutils.patch" "toolchain/patches/gcc.patch" }}
+            - v1-cache-toolchain-{{ checksum "toolchain/CMakeLists.txt" }}
             - v1-cache-toolchain-
             - toolchain-v1
       - run:
@@ -23,7 +23,7 @@ jobs:
           name: Cache Toolchain
           paths:
             - "$CIRCLE_WORKING_DIRECTORY/cmake-build-release/toolchain/output"
-          key: v1-cache-toolchain-{{ checksum "toolchain/CMakeLists.txt" "toolchain/patches/binutils.patch" "toolchain/patches/gcc.patch" }}
+          key: v1-cache-toolchain-{{ checksum "toolchain/CMakeLists.txt" }}
 
   build-hephaestOS:
     docker:
@@ -34,7 +34,7 @@ jobs:
       - restore_cache:
           name: Restore Toolchain
           keys:
-            - cache-toolchain-{{ checksum "toolchain/CMakeLists.txt" "toolchain/patches/binutils.patch" "toolchain/patches/gcc.patch" }}
+            - cache-toolchain-{{ checksum "toolchain/CMakeLists.txt" }}
             - cache-toolchain-
       - run:
           name: "Update libraries"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - restore_cache:
           name: Restore Toolchain
           keys:
-            - v1-cache-toolchain-{{ checksum "toolchain" }}
+            - v1-cache-toolchain-{{ checksum "toolchain/CMakeLists.txt" "toolchain/patches/binutils.patch" "toolchain/patches/gcc.patch" }}
             - v1-cache-toolchain-
             - toolchain-v1
       - run:
@@ -23,7 +23,7 @@ jobs:
           name: Cache Toolchain
           paths:
             - "$CIRCLE_WORKING_DIRECTORY/cmake-build-release/toolchain/output"
-          key: v1-cache-toolchain-{{ checksum "toolchain" }}
+          key: v1-cache-toolchain-{{ checksum "toolchain/CMakeLists.txt" "toolchain/patches/binutils.patch" "toolchain/patches/gcc.patch" }}
 
   build-hephaestOS:
     docker:
@@ -34,7 +34,7 @@ jobs:
       - restore_cache:
           name: Restore Toolchain
           keys:
-            - cache-toolchain-{{ checksum "toolchain/**" }}
+            - cache-toolchain-{{ checksum "toolchain/CMakeLists.txt" "toolchain/patches/binutils.patch" "toolchain/patches/gcc.patch" }}
             - cache-toolchain-
       - run:
           name: "Update libraries"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
             - toolchain-v1
       - run:
           name: "Build toolchain if does not exist"
-          command: "$CIRCLE_WORKING_DIRECTORY/.circleci/build-toolchain.sh"
+          command: ".circleci/build-toolchain.sh"
       - save_cache:
           name: Cache Toolchain
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,10 +7,13 @@ jobs:
     resource_class: medium+
     steps:
       - checkout
+      - run:
+          name: "Build toolchain if does not exist"
+          command: "ls"
       - restore_cache:
           name: Restore Toolchain
           keys:
-            - cache-toolchain-{{ checksum "~/home/circleci/project/toolchain/**" }}
+            - cache-toolchain-{{ checksum "~/home/circleci/project/toolchain/*" }}
             - cache-toolchain-
             - toolchain-v1
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
             - toolchain-v1
       - run:
           name: "Build toolchain if does not exist"
-          command: ".circleci/build-toolchain.sh"
+          command: "chmod u+x .circleci/build-toolchain.sh && .circleci/build-toolchain.sh"
       - save_cache:
           name: Cache Toolchain
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,42 +5,33 @@ jobs:
     docker:
       - image: cimg/base:stable
     resource_class: medium+
-
     steps:
       - checkout
       - restore_cache:
           name: Restore Toolchain
           keys:
+            - cache-toolchain-{{ checksum "/home/circleci/project/toolchain/**" }}
+            - cache-toolchain-
             - toolchain-v1
       - run:
-          name: "Update libraries"
-          command: "sudo apt-get update && sudo apt-get install texinfo flex bison nasm graphviz doxygen ccache libmpfr-dev libmpc-dev doxygen --no-install-recommends -y"
-      - run:
-          name: "Update Cmake to latest"
-          command: "wget https://github.com/Kitware/CMake/releases/download/v3.26.0/cmake-3.26.0-linux-x86_64.tar.gz && tar -zxvf cmake-3.26.0-linux-x86_64.tar.gz && cd cmake-3.26.0-linux-x86_64 && sudo cp -r bin /usr/ && sudo cp -r doc /usr/share/ && sudo cp -r man /usr/share/ && sudo cp -r share /usr/ && cmake --version"
-      - run:
-          name: "Setup and configure cmake for Toolchain"
-          command: "mkdir -p cmake-build-release && cmake -DCMAKE_BUILD_TYPE=Release -B cmake-build-release"
-      - run:
-          name: "Build Gcc Compiler and freestanding C library"
-          command: "cmake --build cmake-build-release --target gcc-12.2.0"
+          name: "Build toolchain if does not exist"
+          command: "sudo ./home/circleci/project/.circleci/build-toolchain.sh"
       - save_cache:
           name: Cache Toolchain
           paths:
-            - "/home/circleci/project/cmake-build-release/toolchain"
-          key: toolchain-v1
+            - "/home/circleci/project/cmake-build-release/toolchain/output"
+          key: cache-toolchain-{{ checksum "/home/circleci/project/toolchain/**" }}
 
-  build-hephaistos:
+  build-hephaestOS:
     docker:
       - image: cimg/base:stable
     resource_class: small
-     
     steps:
       - checkout
       - restore_cache:
           name: Restore Toolchain
           keys:
-            - toolchain-v1
+            - cache-toolchain-
       - run:
           name: "Update libraries"
           command: "sudo apt-get update && sudo apt-get install texinfo flex bison nasm graphviz doxygen ccache libmpfr-dev libmpc-dev doxygen grub-common xorriso --no-install-recommends -y"
@@ -55,11 +46,12 @@ jobs:
           command: "cmake --build cmake-build-release --target HephaistOS.iso"
       - store_artifacts:
           path: /home/circleci/project/cmake-build-release/HephaistOS.iso
+
 workflows:
   version: 2
-  build-hephaistOS-workflow:
+  build-hephaestOS-workflow:
     jobs:
       - build-toolchain
-      - build-hephaistos:
+      - build-hephaestOS:
           requires:
             - build-toolchain

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ jobs:
       - save_cache:
           name: Cache Toolchain
           paths:
-            - "$CIRCLE_WORKING_DIRECTORY/cmake-build-release/toolchain/output"
+            - "cmake-build-release/toolchain/output"
           key: v1-cache-toolchain-{{ checksum "toolchain/CMakeLists.txt" }}
 
   build-hephaestOS:
@@ -31,8 +31,8 @@ jobs:
       - restore_cache:
           name: Restore Toolchain
           keys:
-            - cache-toolchain-{{ checksum "toolchain/CMakeLists.txt" }}
-            - cache-toolchain-
+            - v1-cache-toolchain-{{ checksum "toolchain/CMakeLists.txt" }}
+            - v1-cache-toolchain-
       - run:
           name: "Update libraries"
           command: "sudo apt-get update && sudo apt-get install texinfo flex bison nasm graphviz doxygen ccache libmpfr-dev libmpc-dev doxygen grub-common xorriso --no-install-recommends -y"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
       - restore_cache:
           name: Restore Toolchain
           keys:
-            - cache-toolchain-{{ checksum "~/home/circleci/project/toolchain/*" }}
+            - cache-toolchain-{{ checksum "toolchain/**" }}
             - cache-toolchain-
             - toolchain-v1
       - run:
@@ -23,7 +23,7 @@ jobs:
           name: Cache Toolchain
           paths:
             - "$CIRCLE_WORKING_DIRECTORY/cmake-build-release/toolchain/output"
-          key: cache-toolchain-{{ checksum "~/home/circleci/project/toolchain/**" }}
+          key: cache-toolchain-{{ checksum "toolchain/**" }}
 
   build-hephaestOS:
     docker:
@@ -34,7 +34,7 @@ jobs:
       - restore_cache:
           name: Restore Toolchain
           keys:
-            - cache-toolchain-{{ checksum "~/home/circleci/project/toolchain/**" }}
+            - cache-toolchain-{{ checksum "toolchain/**" }}
             - cache-toolchain-
       - run:
           name: "Update libraries"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,9 +7,6 @@ jobs:
     resource_class: medium+
     steps:
       - checkout
-      - run:
-          name: "Build toolchain if does not exist"
-          command: "ls"
       - restore_cache:
           name: Restore Toolchain
           keys:
@@ -18,7 +15,7 @@ jobs:
             - toolchain-v1
       - run:
           name: "Build toolchain if does not exist"
-          command: "sudo .$CIRCLE_WORKING_DIRECTORY/.circleci/build-toolchain.sh"
+          command: "sh $CIRCLE_WORKING_DIRECTORY/.circleci/build-toolchain.sh"
       - save_cache:
           name: Cache Toolchain
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,8 @@ jobs:
       - restore_cache:
           name: Restore Toolchain
           keys:
-            - v1-cache-toolchain-{{ checksum "toolchain/CMakeLists.txt" }}
-            - v1-cache-toolchain-
+            - v2-cache-toolchain-{{ checksum "toolchain/CMakeLists.txt" }}
+            - v2-cache-toolchain-
             - toolchain-v1
       - run:
           name: "Build toolchain if does not exist"
@@ -20,7 +20,7 @@ jobs:
           name: Cache Toolchain
           paths:
             - "cmake-build-release/toolchain/output"
-          key: v1-cache-toolchain-{{ checksum "toolchain/CMakeLists.txt" }}
+          key: v2-cache-toolchain-{{ checksum "toolchain/CMakeLists.txt" }}
 
   build-hephaestOS:
     docker:
@@ -31,8 +31,8 @@ jobs:
       - restore_cache:
           name: Restore Toolchain
           keys:
-            - v1-cache-toolchain-{{ checksum "toolchain/CMakeLists.txt" }}
-            - v1-cache-toolchain-
+            - v2-cache-toolchain-{{ checksum "toolchain/CMakeLists.txt" }}
+            - v2-cache-toolchain-
       - run:
           name: "Update libraries"
           command: "sudo apt-get update && sudo apt-get install texinfo flex bison nasm graphviz doxygen ccache libmpfr-dev libmpc-dev doxygen grub-common xorriso --no-install-recommends -y"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,8 @@ jobs:
       - restore_cache:
           name: Restore Toolchain
           keys:
-            - cache-toolchain-{{ checksum "toolchain/**" }}
-            - cache-toolchain-
+            - v1-cache-toolchain-{{ checksum "toolchain" }}
+            - v1-cache-toolchain-
             - toolchain-v1
       - run:
           name: "Build toolchain if does not exist"
@@ -23,7 +23,7 @@ jobs:
           name: Cache Toolchain
           paths:
             - "$CIRCLE_WORKING_DIRECTORY/cmake-build-release/toolchain/output"
-          key: cache-toolchain-{{ checksum "toolchain/**" }}
+          key: v1-cache-toolchain-{{ checksum "toolchain" }}
 
   build-hephaestOS:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,17 +10,17 @@ jobs:
       - restore_cache:
           name: Restore Toolchain
           keys:
-            - cache-toolchain-{{ checksum "/home/circleci/project/toolchain/**" }}
+            - cache-toolchain-{{ checksum "$CIRCLE_WORKING_DIRECTORY/toolchain/**" }}
             - cache-toolchain-
             - toolchain-v1
       - run:
           name: "Build toolchain if does not exist"
-          command: "sudo ./home/circleci/project/.circleci/build-toolchain.sh"
+          command: "sudo .$CIRCLE_WORKING_DIRECTORY/.circleci/build-toolchain.sh"
       - save_cache:
           name: Cache Toolchain
           paths:
-            - "/home/circleci/project/cmake-build-release/toolchain/output"
-          key: cache-toolchain-{{ checksum "/home/circleci/project/toolchain/**" }}
+            - "$CIRCLE_WORKING_DIRECTORY/cmake-build-release/toolchain/output"
+          key: cache-toolchain-{{ checksum "$CIRCLE_WORKING_DIRECTORY/toolchain/**" }}
 
   build-hephaestOS:
     docker:
@@ -31,6 +31,7 @@ jobs:
       - restore_cache:
           name: Restore Toolchain
           keys:
+            - cache-toolchain-{{ checksum "$CIRCLE_WORKING_DIRECTORY/toolchain/**" }}
             - cache-toolchain-
       - run:
           name: "Update libraries"


### PR DESCRIPTION
This change adds a skip into the first build step if the toolchain already exists for the same cmake checksum